### PR TITLE
Expose forward method 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,37 @@ pub fn extract_request_data_filter(
 
 /// Build a request and send to the requested address. wraps the response into a
 /// warp::reply compatible type (`http::Response`)
-async fn proxy_to_and_forward_response(
+///
+/// # Arguments
+///
+/// * `proxy_address` - A string containing the base proxy address where the request
+/// will be forwarded to.
+///
+/// * `base_path` - A string with the prepended sub-path to be stripped from the request uri path.
+///
+/// * `uri` -> The uri of the extracted request.
+///
+/// * `method` -> The request method.
+///
+/// * `headers` -> The request headers.
+///
+/// * `body` -> The request body.
+///
+/// # Examples
+/// Notice that this method usually need to be used in aggregation with
+/// the [`extract_request_data_filter`](fn.extract_request_data_filter.html) filter` which already
+/// provides the `(uri, method, headers, body)` needed for calling this method. But the `proxy_address`
+/// and the `base_path` arguments need to be provided too.
+/// ```rust, ignore
+/// let request_filter = extract_request_data_filter();
+///     let app = warp::path!("hello" / String)
+///         .map(|port| (format!("http://127.0.0.1:{}/", port), "".to_string()))
+///         .untuple_one()
+///         .and(request_filter)
+///         .and_then(proxy_to_and_forward_response)
+///         .and_then(log_response);
+/// ```
+pub async fn proxy_to_and_forward_response(
     proxy_address: String,
     mut base_path: String,
     uri: FullPath,
@@ -111,12 +141,11 @@ async fn proxy_to_and_forward_response(
     if !base_path.starts_with('/') {
         base_path = format!("/{}", base_path);
     }
-    let request = filtered_data_to_request(
-        proxy_address,
-        base_path,
-        (uri, params, method, headers, body),
-    )
-    .map_err(warp::reject::custom)?;
+    let request = filtered_data_to_request(proxy_address, (uri, params, method, headers, body))
+        .map_err(warp::reject::custom)?;
+    let proxy_uri = remove_relative_path(&uri, base_path, proxy_address);
+    let request = filtered_data_to_request(proxy_uri, (uri, params, method, headers, body))
+        .map_err(warp::reject::custom)?;
     let response = proxy_request(request).await.map_err(warp::reject::custom)?;
     response_to_reply(response)
         .await
@@ -135,6 +164,19 @@ async fn response_to_reply(
         .status(response.status())
         .body(response.bytes().await.map_err(errors::Error::Request)?)
         .map_err(errors::Error::HTTP)
+}
+
+fn remove_relative_path(uri: &FullPath, mut base_path: String, proxy_address: String) -> String {
+    if !base_path.starts_with('/') {
+        base_path = format!("/{}", base_path);
+    }
+    let relative_path = uri
+        .as_str()
+        .trim_start_matches(&base_path)
+        .trim_start_matches('/');
+
+    let proxy_address = proxy_address.trim_end_matches('/');
+    format!("{}/{}", proxy_address, relative_path)
 }
 
 /// Checker method to filter hop headers
@@ -171,7 +213,6 @@ fn remove_hop_headers(headers: &HeaderMap<HeaderValue>) -> HeaderMap<HeaderValue
 
 fn filtered_data_to_request(
     proxy_address: String,
-    base_path: String,
     request: Request,
 ) -> Result<reqwest::Request, errors::Error> {
     let (uri, params, method, headers, body) = request;
@@ -193,7 +234,7 @@ fn filtered_data_to_request(
 
     let client = reqwest::Client::new();
     client
-        .request(method, &proxy_uri)
+        .request(method, &proxy_address)
         .headers(headers)
         .body(body)
         .build()
@@ -212,8 +253,8 @@ async fn proxy_request(request: reqwest::Request) -> Result<reqwest::Response, e
 #[cfg(test)]
 pub mod test {
     use crate::{
-        extract_request_data_filter, filtered_data_to_request, proxy_request, reverse_proxy_filter,
-        Request,
+        extract_request_data_filter, filtered_data_to_request, proxy_request, remove_relative_path,
+        reverse_proxy_filter, Request,
     };
     use std::net::SocketAddr;
     use warp::http::StatusCode;
@@ -278,9 +319,15 @@ pub mod test {
 
         tokio::task::yield_now().await;
         // transform request data into an actual request
-        let request =
-            filtered_data_to_request("http://127.0.0.1:4040".to_string(), "".to_string(), request)
-                .unwrap();
+        let request = filtered_data_to_request(
+            remove_relative_path(
+                &request.0,
+                "".to_string(),
+                "http://127.0.0.1:4040".to_string(),
+            ),
+            request,
+        )
+        .unwrap();
         let response = proxy_request(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,16 +211,12 @@ fn filtered_data_to_request(
     proxy_address: String,
     request: Request,
 ) -> Result<reqwest::Request, errors::Error> {
-    let (uri, params, method, headers, body) = request;
-
-    let relative_path = uri.as_str().trim_start_matches('/');
-
-    let proxy_address = proxy_address.trim_end_matches('/');
+    let (_uri, params, method, headers, body) = request;
 
     let proxy_uri = if let Some(params) = params {
-        format!("{}/{}?{}", proxy_address, relative_path, params)
+        format!("{}?{}", proxy_address, params)
     } else {
-        format!("{}/{}", proxy_address, relative_path)
+        proxy_address
     };
 
     let headers = remove_hop_headers(&headers);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,8 @@ pub fn extract_request_data_filter(
 ///
 /// * `uri` -> The uri of the extracted request.
 ///
+/// * `params` -> The URL query parameters
+///
 /// * `method` -> The request method.
 ///
 /// * `headers` -> The request headers.
@@ -122,12 +124,12 @@ pub fn extract_request_data_filter(
 /// and the `base_path` arguments need to be provided too.
 /// ```rust, ignore
 /// let request_filter = extract_request_data_filter();
-///     let app = warp::path!("hello" / String)
-///         .map(|port| (format!("http://127.0.0.1:{}/", port), "".to_string()))
-///         .untuple_one()
-///         .and(request_filter)
-///         .and_then(proxy_to_and_forward_response)
-///         .and_then(log_response);
+/// let app = warp::path!("hello" / String)
+///     .map(|port| (format!("http://127.0.0.1:{}/", port), "".to_string()))
+///     .untuple_one()
+///     .and(request_filter)
+///     .and_then(proxy_to_and_forward_response)
+///     .and_then(log_response);
 /// ```
 pub async fn proxy_to_and_forward_response(
     proxy_address: String,


### PR DESCRIPTION
In order to support more advanced composition for the forwarding addresses, the `proxy_to_and_forward_response` is exposed. This makes it easier to compose with other filters that would compute the proxy address. For example:


```rust
use warp::{hyper::body::Bytes, Filter, Rejection, Reply};
use warp_reverse_proxy::{
    extract_request_data_filter, proxy_to_and_forward_response, reverse_proxy_filter,
};

async fn log_response(response: http::Response<Bytes>) -> Result<impl Reply, Rejection> {
    println!("{:?}", response);
    Ok(response)
}

#[tokio::main]
async fn main() {
    let hello = warp::path!("hello" / String).map(|name| format!("Hello port, {}!", name));

    // // spawn base server
    tokio::spawn(warp::serve(hello).run(([0, 0, 0, 0], 8080)));

    let request_filter = extract_request_data_filter();
    let app = warp::path!("hello" / String)
        .map(|port| (format!("http://127.0.0.1:{}/", port), "".to_string()))
        .untuple_one()
        .and(request_filter)
        .and_then(proxy_to_and_forward_response)
        .and_then(log_response);

    // spawn proxy server
    warp::serve(app).run(([0, 0, 0, 0], 3030)).await;
}
```

This app uses the path to extract the port where to communicate with.

Implements #10 