### PR TITLE
add option to use rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = [
 [dependencies]
 hyper = "0.13.7"
 lazy_static = "1.4.0"
-reqwest = "0.10.7"
+reqwest = { version = "0.10.7", default-features = false}
 thiserror = "1.0.20"
 unicase = "2.6.0"
 warp = "0.2.4"
@@ -27,3 +27,7 @@ warp = "0.2.4"
 [dev-dependencies]
 bytes = "0.5.6"
 tokio = { version = "0.2.22", features = ["macros"] }
+[features]
+default = ["default-tls"]
+default-tls = ["reqwest/default-tls"]
+rustls-tls = ["reqwest/rustls-tls"]


### PR DESCRIPTION
Allows people to switch from reqwest's default tls back to rustls.

```toml
warp-reverse-proxy = { version = "0.2.0", default_features = false, features = ["rustls-tls"] }
```