### PR TITLE
Update to warp 3.0 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ warp = "0.3"
 
 [dev-dependencies]
 bytes = "1.0"
-tokio = { version = "1", features = ["macros"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 [features]
 default = ["default-tls"]
 default-tls = ["reqwest/default-tls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,16 +17,16 @@ exclude = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hyper = "0.13.7"
+hyper = "0.14"
 lazy_static = "1.4.0"
-reqwest = { version = "0.10.7", default-features = false}
-thiserror = "1.0.20"
+reqwest = { version = "0.11", default-features = false}
+thiserror = "1.0.23"
 unicase = "2.6.0"
-warp = "0.2.4"
+warp = "0.3"
 
 [dev-dependencies]
-bytes = "0.5.6"
-tokio = { version = "0.2.22", features = ["macros"] }
+bytes = "1.0"
+tokio = { version = "1", features = ["macros"] }
 [features]
 default = ["default-tls"]
 default-tls = ["reqwest/default-tls"]


### PR DESCRIPTION
# Description of change

Warp 3.0 is finally released which makes use of tokio 1 :)
This PR updates all dependencies.

## How the change has been tested

I did run all the tests in `lib.rs`. All tests did pass.



