### PR TITLE
Reuse the same client to create requests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,8 +235,7 @@ fn filtered_data_to_request(
 
     let headers = remove_hop_headers(&headers);
 
-    let client = reqwest::Client::new();
-    client
+    CLIENT
         .request(method, &proxy_uri)
         .headers(headers)
         .body(body)


### PR DESCRIPTION
Reusing the same client for creating requests is more efficient than building a new one each time.