### PR TITLE
Stream upstream response instead of buffering everything first

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 [dependencies]
 hyper = "0.14"
 once_cell = "1.10"
-reqwest = { version = "0.11", default-features = false}
+reqwest = { version = "0.11", default-features = false, features = ["stream"] }
 thiserror = "1.0"
 unicase = "2.6"
 warp = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,10 +3,10 @@
 //!
 //!
 //! ```no_run
-//! use warp::{hyper::body::Bytes, Filter, Rejection, Reply, http::Response};
+//! use warp::{hyper::Body, Filter, Rejection, Reply, http::Response};
 //! use warp_reverse_proxy::reverse_proxy_filter;
 //!
-//! async fn log_response(response: Response<Bytes>) -> Result<impl Reply, Rejection> {
+//! async fn log_response(response: Response<Body>) -> Result<impl Reply, Rejection> {
 //!     println!("{:?}", response);
 //!     Ok(response)
 //! }
@@ -149,6 +149,14 @@ pub fn extract_request_data_filter(
 /// provides the `(Uri, QueryParameters, Method, Headers, Body)` needed for calling this method. But the `proxy_address`
 /// and the `base_path` arguments need to be provided too.
 /// ```rust, ignore
+/// use warp::{Filter, hyper::Body, Reply, Rejection, hyper::Response};
+/// use warp_reverse_proxy::{extract_request_data_filter, proxy_to_and_forward_response};
+///
+/// async fn log_response(response: Response<Body>) -> Result<impl Reply, Rejection> {
+///     println!("{:?}", response);
+///     Ok(response)
+/// }
+///
 /// let request_filter = extract_request_data_filter();
 /// let app = warp::path!("hello" / String)
 ///     .map(|port| (format!("http://127.0.0.1:{}/", port), "".to_string()))


### PR DESCRIPTION
This is a breaking API change but helps with some clients disconnecting due to:

```
Operation too slow. Less than 1 bytes/sec transferred the last 10 seconds
```