### PR TITLE
Do not depend on warp default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ once_cell = "1.16"
 reqwest = { version = "0.11", default-features = false, features = ["stream"] }
 thiserror = "1.0"
 unicase = "2.6"
-warp = "0.3"
+warp = { version = "0.3", default-features = false }
 
 [dev-dependencies]
 bytes = "1.0"


### PR DESCRIPTION
Hey there, just got a warning in my project starting Rust 1.68 that in future Rust version it won't compile because of `buf_redux` crate which is a transitive dependency of this crate through `multipart` crate which is also a default feature of warp.

Since this is not required by this crate, I propose you to stop relying upon warp default features.

More details about the compilation issue [here](https://github.com/abonander/buf_redux/issues/23). It looks like it won't be resolved anytime soon